### PR TITLE
Added boot method selection

### DIFF
--- a/homesoft-client/application.mk
+++ b/homesoft-client/application.mk
@@ -1,0 +1,8 @@
+ifeq ($(DEBUG),true)
+    $(info >Starting application.mk)
+endif
+
+ifeq ($(ENABLE_BOOTSEL),1)
+CFLAGS += -DENABLE_BOOTSEL
+endif
+


### PR DESCRIPTION
Select key changes load/boot method:
A = Load using N device over TNFS
B = Load using N device over HTTPS
C = Disk mount and boot over TNFS
D = Disk mount and boot over HTTPS

If ATR is choosen, disk mount and boot (C or D) is used automatically. For ATR, A is the same as C and B is the same as D.

Added query option "d=1" to include ATR images in result

Build with make variable set ENABLE_BOOTSEL=1
E.g make -C homesoft-client ENABLE_BOOTSEL=1 clean disk
Alternatively, modify application.mk to change the default value.